### PR TITLE
feat: Phase 8 Admin Panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,6 @@ Reference screenshots from the original OSMO Supply app are stored in `docs/refe
 | State | Pinia (@pinia/nuxt) | 0.11.3 |
 | Backend | Appwrite (appwrite SDK) | 22.0.0 |
 | Payments | Stripe | TBD |
-| Content | @nuxt/content | 3.11.2 |
 | Images | @nuxt/image | 2.0.0 |
 | Scripts | @nuxt/scripts | 0.13.2 |
 | Icons | Lucide + Simple Icons (Iconify) | - |
@@ -430,3 +429,45 @@ interface UserProfile {
 8. **Category counts**: Computed client-side from resources list or cached via Appwrite function. Not a static stored field.
 9. **No SSR auth**: Auth is client-side only via the `appwrite` Web SDK. Middleware auth checks run client-side.
 10. **Stripe webhooks = source of truth**: Client never directly modifies subscription state.
+
+## Project Roadmap
+
+### Abgeschlossene Phasen
+
+| Phase | Beschreibung | Status |
+|-------|-------------|--------|
+| 1 | Foundation (Types, Layouts, Mock-Daten, Dark Theme) | ✅ Done |
+| 2 | Landing Page & Public Pages (Hero, Features, Pricing) | ✅ Done |
+| 3 | Auth (Login, Register, OAuth, Middleware, Stores) | ✅ Done |
+| 4 | Vault Core (Sidebar, Card Grid, Kategorien, Filtering) | ✅ Done |
+| 5 | Resource Detail (Preview, Code Steps, Meta Sidebar, Lock) | ✅ Done |
+| 6 | Search (Command Palette, Meta+K, Keyboard Navigation) | ✅ Done |
+| 7 | Appwrite Anbindung (Dual-Mode Composables, SDK Migration) | ✅ Done |
+
+### Offene Phasen
+
+**Phase 8: Admin Panel**
+- Admin Layout + Middleware (Appwrite Team/Label Check)
+- Resource CRUD (UTable, Create/Edit Formular, Thumbnail Upload)
+- Category Management (Name, Slug, Icon, Sort Order)
+- Admin Dashboard (Übersicht: Ressourcen-Count, User-Count)
+
+**Phase 9: Stripe & Premium**
+- Stripe Checkout Endpoint + Webhook Endpoint
+- Subscription Composable (Status lesen, Checkout starten, Portal öffnen)
+- Pricing Page verknüpfen, Premium Gating aktivieren
+- node-appwrite Server SDK für Webhook-Updates
+- Customer Portal + Success/Cancel Pages
+
+**Phase 10: Polish & UX**
+- SEO Meta Tags (useSeoMeta für alle Seiten)
+- Error Handling (Error Boundary, 404, Toast-Fehler)
+- Loading States (Skeleton-Loader)
+- Responsive Design, Accessibility, Performance
+- Image Optimization (@nuxt/image), Animations
+
+**Phase 11: Testing & Deployment**
+- TypeCheck + ESLint Clean + Production Build Test
+- E2E Flow Testing (Register → Login → Browse → Checkout → Premium)
+- Deployment Config (Vercel/Cloudflare/Netlify)
+- CI/CD Pipeline, Domain + SSL, Stripe Live Mode

--- a/app/components/Admin/AdminResourceForm.vue
+++ b/app/components/Admin/AdminResourceForm.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import type { Resource, ResourceCode, Category } from '~/types'
+import type { FormSubmitEvent } from '#ui/types'
+
+const props = defineProps<{
+  resource?: Resource
+  resourceCode?: ResourceCode | null
+  categories: Category[]
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  submit: [data: { resource: Partial<Resource>, code: Partial<ResourceCode> }]
+}>()
+
+const isEditing = computed(() => !!props.resource)
+
+// Form state
+const state = reactive({
+  title: props.resource?.title ?? '',
+  slug: props.resource?.slug ?? '',
+  description: props.resource?.description ?? '',
+  category: props.resource?.category ?? '',
+  tags: props.resource?.tags?.join(', ') ?? '',
+  isFree: props.resource?.isFree ?? true,
+  isNew: props.resource?.isNew ?? false,
+  sortOrder: props.resource?.sortOrder ?? 0,
+  externalScripts: props.resource?.externalScripts?.join('\n') ?? '',
+  previewUrl: props.resource?.previewUrl ?? '',
+  originalSourceUrl: props.resource?.originalSourceUrl ?? '',
+  authorName: props.resource?.authorName ?? '',
+  authorAvatarUrl: props.resource?.authorAvatarUrl ?? '',
+  // Code fields
+  htmlCode: props.resourceCode?.htmlCode ?? '',
+  cssCode: props.resourceCode?.cssCode ?? '',
+  jsCode: props.resourceCode?.jsCode ?? '',
+  implementationNotes: props.resourceCode?.implementationNotes ?? ''
+})
+
+// Auto-generate slug from title (only for new resources)
+watch(() => state.title, (title) => {
+  if (!isEditing.value) {
+    state.slug = title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+  }
+})
+
+// Category options for select
+const categoryOptions = computed(() =>
+  props.categories.map(c => ({ label: c.name, value: c.$id }))
+)
+
+// Validation
+function validate(formState: typeof state) {
+  const errors: { name: string, message: string }[] = []
+  if (!formState.title) errors.push({ name: 'title', message: 'Title is required' })
+  if (!formState.slug) errors.push({ name: 'slug', message: 'Slug is required' })
+  if (!formState.category) errors.push({ name: 'category', message: 'Category is required' })
+  return errors
+}
+
+function onSubmit(event: FormSubmitEvent<typeof state>) {
+  const tags = String(event.data.tags)
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean)
+  const externalScripts = String(event.data.externalScripts)
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+
+  emit('submit', {
+    resource: {
+      title: event.data.title,
+      slug: event.data.slug,
+      description: event.data.description,
+      category: event.data.category,
+      tags,
+      isFree: event.data.isFree,
+      isNew: event.data.isNew,
+      sortOrder: Number(event.data.sortOrder),
+      externalScripts: externalScripts.length ? externalScripts : undefined,
+      previewUrl: event.data.previewUrl || undefined,
+      originalSourceUrl: event.data.originalSourceUrl || undefined,
+      authorName: event.data.authorName || undefined,
+      authorAvatarUrl: event.data.authorAvatarUrl || undefined,
+      thumbnailFileId: props.resource?.thumbnailFileId ?? ''
+    },
+    code: {
+      htmlCode: event.data.htmlCode,
+      cssCode: event.data.cssCode,
+      jsCode: event.data.jsCode,
+      implementationNotes: event.data.implementationNotes || undefined
+    }
+  })
+}
+</script>
+
+<template>
+  <UForm
+    :validate="validate"
+    :state="state"
+    class="space-y-6"
+    @submit="onSubmit"
+  >
+    <!-- Resource Metadata -->
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">
+          Resource Details
+        </h2>
+      </template>
+
+      <div class="space-y-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <UFormField
+            label="Title"
+            name="title"
+            required
+          >
+            <UInput
+              v-model="state.title"
+              placeholder="Elastic Pulse Button"
+            />
+          </UFormField>
+          <UFormField
+            label="Slug"
+            name="slug"
+            required
+          >
+            <UInput
+              v-model="state.slug"
+              placeholder="elastic-pulse-button"
+            />
+          </UFormField>
+        </div>
+
+        <UFormField
+          label="Description"
+          name="description"
+        >
+          <UTextarea
+            v-model="state.description"
+            :rows="3"
+            placeholder="A brief description of this resource..."
+          />
+        </UFormField>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <UFormField
+            label="Category"
+            name="category"
+            required
+          >
+            <USelect
+              v-model="state.category"
+              :items="categoryOptions"
+              placeholder="Select category..."
+            />
+          </UFormField>
+          <UFormField
+            label="Sort Order"
+            name="sortOrder"
+          >
+            <UInput
+              v-model="state.sortOrder"
+              type="number"
+            />
+          </UFormField>
+          <div class="flex items-end gap-6 pb-1">
+            <UFormField name="isFree">
+              <USwitch
+                v-model="state.isFree"
+                label="Free"
+              />
+            </UFormField>
+            <UFormField name="isNew">
+              <USwitch
+                v-model="state.isNew"
+                label="New"
+              />
+            </UFormField>
+          </div>
+        </div>
+
+        <UFormField
+          label="Tags"
+          name="tags"
+          hint="Comma separated"
+        >
+          <UInput
+            v-model="state.tags"
+            placeholder="Button, Hover, Animation"
+          />
+        </UFormField>
+      </div>
+    </UCard>
+
+    <!-- Code Section -->
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">
+          Code
+        </h2>
+      </template>
+
+      <div class="space-y-4">
+        <UFormField
+          label="HTML"
+          name="htmlCode"
+        >
+          <UTextarea
+            v-model="state.htmlCode"
+            :rows="8"
+            class="font-mono text-sm"
+            placeholder="<div class='container'>...</div>"
+          />
+        </UFormField>
+        <UFormField
+          label="CSS"
+          name="cssCode"
+        >
+          <UTextarea
+            v-model="state.cssCode"
+            :rows="8"
+            class="font-mono text-sm"
+            placeholder=".container { ... }"
+          />
+        </UFormField>
+        <UFormField
+          label="JavaScript"
+          name="jsCode"
+        >
+          <UTextarea
+            v-model="state.jsCode"
+            :rows="8"
+            class="font-mono text-sm"
+            placeholder="document.querySelector('.container')..."
+          />
+        </UFormField>
+        <UFormField
+          label="Implementation Notes (Markdown)"
+          name="implementationNotes"
+        >
+          <UTextarea
+            v-model="state.implementationNotes"
+            :rows="6"
+            placeholder="## Usage\nDescribe how to use this resource..."
+          />
+        </UFormField>
+      </div>
+    </UCard>
+
+    <!-- Optional Fields -->
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">
+          Optional
+        </h2>
+      </template>
+
+      <div class="space-y-4">
+        <UFormField
+          label="External Scripts"
+          name="externalScripts"
+          hint="One URL per line"
+        >
+          <UTextarea
+            v-model="state.externalScripts"
+            :rows="3"
+            placeholder="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"
+          />
+        </UFormField>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <UFormField
+            label="Author Name"
+            name="authorName"
+          >
+            <UInput
+              v-model="state.authorName"
+              placeholder="John Doe"
+            />
+          </UFormField>
+          <UFormField
+            label="Original Source URL"
+            name="originalSourceUrl"
+          >
+            <UInput
+              v-model="state.originalSourceUrl"
+              placeholder="https://codepen.io/..."
+            />
+          </UFormField>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <UFormField
+            label="Preview URL"
+            name="previewUrl"
+          >
+            <UInput
+              v-model="state.previewUrl"
+              placeholder="https://preview.example.com/..."
+            />
+          </UFormField>
+          <UFormField
+            label="Author Avatar URL"
+            name="authorAvatarUrl"
+          >
+            <UInput
+              v-model="state.authorAvatarUrl"
+              placeholder="https://avatars.githubusercontent.com/..."
+            />
+          </UFormField>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Submit -->
+    <div class="flex items-center gap-2">
+      <UButton
+        type="submit"
+        :loading="loading"
+      >
+        {{ isEditing ? 'Update Resource' : 'Create Resource' }}
+      </UButton>
+      <UButton
+        to="/admin/resources"
+        variant="outline"
+        color="neutral"
+        label="Cancel"
+      />
+    </div>
+  </UForm>
+</template>

--- a/app/components/Admin/AdminSidebar.vue
+++ b/app/components/Admin/AdminSidebar.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+const route = useRoute()
+
+const navItems = computed(() => [
+  {
+    label: 'Dashboard',
+    icon: 'i-lucide-layout-dashboard',
+    to: '/admin',
+    active: route.path === '/admin'
+  },
+  {
+    label: 'Resources',
+    icon: 'i-lucide-file-code',
+    to: '/admin/resources',
+    active: route.path.startsWith('/admin/resources')
+  },
+  {
+    label: 'Categories',
+    icon: 'i-lucide-folder',
+    to: '/admin/categories',
+    active: route.path === '/admin/categories'
+  }
+])
+
+const bottomItems = computed(() => [
+  {
+    label: 'Back to Vault',
+    icon: 'i-lucide-arrow-left',
+    to: '/vault'
+  }
+])
+</script>
+
+<template>
+  <UDashboardSidebar
+    collapsible
+    resizable
+    :min-size="200"
+    :default-size="260"
+    :max-size="320"
+  >
+    <template #header>
+      <NuxtLink
+        to="/admin"
+        class="flex items-center gap-2 px-2"
+      >
+        <UIcon
+          name="i-lucide-shield"
+          class="size-5 text-primary"
+        />
+        <span class="font-bold text-sm truncate group-data-[collapsed]/sidebar:hidden">
+          Admin Panel
+        </span>
+      </NuxtLink>
+    </template>
+
+    <UNavigationMenu
+      :items="navItems"
+      orientation="vertical"
+    />
+
+    <USeparator class="my-2" />
+
+    <UNavigationMenu
+      :items="bottomItems"
+      orientation="vertical"
+    />
+
+    <template #footer>
+      <AppUserMenu />
+    </template>
+  </UDashboardSidebar>
+</template>

--- a/app/components/App/AppUserMenu.vue
+++ b/app/components/App/AppUserMenu.vue
@@ -24,6 +24,13 @@ const subscriptionLabel = computed(() => {
 })
 
 const menuItems = computed(() => [
+  ...(authStore.isAdmin
+    ? [[{
+        label: 'Admin Panel',
+        icon: 'i-lucide-shield',
+        to: '/admin'
+      }]]
+    : []),
   [{
     label: 'Account',
     icon: 'i-lucide-user',

--- a/app/composables/useAdmin.ts
+++ b/app/composables/useAdmin.ts
@@ -1,0 +1,311 @@
+import type { Resource, ResourceCode, Category } from '~/types'
+import { APPWRITE } from '~/utils/constants'
+
+// Auto-detect mock mode
+const MOCK_MODE = !import.meta.env.NUXT_PUBLIC_APPWRITE_PROJECT
+  || import.meta.env.NUXT_PUBLIC_APPWRITE_PROJECT === ''
+  || import.meta.env.NUXT_PUBLIC_APPWRITE_PROJECT === 'placeholder'
+
+export function useAdmin() {
+  const vaultStore = useVaultStore()
+  const toast = useToast()
+
+  // ─── Resources ──────────────────────────────
+
+  async function createResource(
+    data: Omit<Resource, '$id' | '$createdAt' | '$updatedAt' | 'thumbnailUrl'>
+  ): Promise<Resource | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        const newResource: Resource = {
+          ...data,
+          $id: `res-${Date.now()}`,
+          $createdAt: new Date().toISOString(),
+          $updatedAt: new Date().toISOString()
+        }
+        vaultStore.setResources([...vaultStore.resources, newResource])
+        toast.add({ title: 'Resource created', description: data.title })
+        return newResource
+      } else {
+        const { databases, ID, Permission, Role } = useAppwrite()
+        const doc = await databases.createDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.RESOURCES,
+          documentId: ID.unique(),
+          data,
+          permissions: [Permission.read(Role.any())]
+        })
+        const resource = doc as unknown as Resource
+        vaultStore.setResources([...vaultStore.resources, resource])
+        toast.add({ title: 'Resource created', description: data.title })
+        return resource
+      }
+    } catch (error) {
+      console.error('Failed to create resource:', error)
+      toast.add({ title: 'Failed to create resource', color: 'error' })
+      return null
+    }
+  }
+
+  async function updateResource(
+    id: string,
+    data: Partial<Omit<Resource, '$id' | '$createdAt' | '$updatedAt'>>
+  ): Promise<Resource | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        const updated = vaultStore.resources.map(r =>
+          r.$id === id ? { ...r, ...data, $updatedAt: new Date().toISOString() } : r
+        )
+        vaultStore.setResources(updated)
+        toast.add({ title: 'Resource updated' })
+        return updated.find(r => r.$id === id) ?? null
+      } else {
+        const { databases } = useAppwrite()
+        const doc = await databases.updateDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.RESOURCES,
+          documentId: id,
+          data
+        })
+        const resource = doc as unknown as Resource
+        const updated = vaultStore.resources.map(r => r.$id === id ? resource : r)
+        vaultStore.setResources(updated)
+        toast.add({ title: 'Resource updated' })
+        return resource
+      }
+    } catch (error) {
+      console.error('Failed to update resource:', error)
+      toast.add({ title: 'Failed to update resource', color: 'error' })
+      return null
+    }
+  }
+
+  async function deleteResource(id: string): Promise<boolean> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        vaultStore.setResources(vaultStore.resources.filter(r => r.$id !== id))
+        toast.add({ title: 'Resource deleted' })
+        return true
+      } else {
+        const { databases } = useAppwrite()
+        await databases.deleteDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.RESOURCES,
+          documentId: id
+        })
+        vaultStore.setResources(vaultStore.resources.filter(r => r.$id !== id))
+        toast.add({ title: 'Resource deleted' })
+        return true
+      }
+    } catch (error) {
+      console.error('Failed to delete resource:', error)
+      toast.add({ title: 'Failed to delete resource', color: 'error' })
+      return false
+    }
+  }
+
+  // ─── Resource Code ──────────────────────────
+
+  async function createResourceCode(
+    data: Omit<ResourceCode, '$id' | '$createdAt' | '$updatedAt'>
+  ): Promise<ResourceCode | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 200))
+        const newCode: ResourceCode = {
+          ...data,
+          $id: `code-${Date.now()}`,
+          $createdAt: new Date().toISOString(),
+          $updatedAt: new Date().toISOString()
+        }
+        toast.add({ title: 'Resource code saved' })
+        return newCode
+      } else {
+        const { databases, ID } = useAppwrite()
+        const doc = await databases.createDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.RESOURCE_CODE,
+          documentId: ID.unique(),
+          data
+        })
+        toast.add({ title: 'Resource code saved' })
+        return doc as unknown as ResourceCode
+      }
+    } catch (error) {
+      console.error('Failed to create resource code:', error)
+      toast.add({ title: 'Failed to save resource code', color: 'error' })
+      return null
+    }
+  }
+
+  async function updateResourceCode(
+    id: string,
+    data: Partial<Omit<ResourceCode, '$id' | '$createdAt' | '$updatedAt'>>
+  ): Promise<ResourceCode | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 200))
+        toast.add({ title: 'Resource code updated' })
+        return { $id: id, $createdAt: '', $updatedAt: new Date().toISOString(), resourceId: '', htmlCode: '', cssCode: '', jsCode: '', ...data } as ResourceCode
+      } else {
+        const { databases } = useAppwrite()
+        const doc = await databases.updateDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.RESOURCE_CODE,
+          documentId: id,
+          data
+        })
+        toast.add({ title: 'Resource code updated' })
+        return doc as unknown as ResourceCode
+      }
+    } catch (error) {
+      console.error('Failed to update resource code:', error)
+      toast.add({ title: 'Failed to update resource code', color: 'error' })
+      return null
+    }
+  }
+
+  // ─── Categories ─────────────────────────────
+
+  async function createCategory(
+    data: Omit<Category, '$id'>
+  ): Promise<Category | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        const newCat: Category = {
+          ...data,
+          $id: `cat-${Date.now()}`
+        }
+        vaultStore.setCategories([...vaultStore.categories, newCat])
+        toast.add({ title: 'Category created', description: data.name })
+        return newCat
+      } else {
+        const { databases, ID } = useAppwrite()
+        const doc = await databases.createDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.CATEGORIES,
+          documentId: ID.unique(),
+          data
+        })
+        const category = doc as unknown as Category
+        vaultStore.setCategories([...vaultStore.categories, category])
+        toast.add({ title: 'Category created', description: data.name })
+        return category
+      }
+    } catch (error) {
+      console.error('Failed to create category:', error)
+      toast.add({ title: 'Failed to create category', color: 'error' })
+      return null
+    }
+  }
+
+  async function updateCategory(
+    id: string,
+    data: Partial<Omit<Category, '$id'>>
+  ): Promise<Category | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        const updated = vaultStore.categories.map(c =>
+          c.$id === id ? { ...c, ...data } : c
+        )
+        vaultStore.setCategories(updated)
+        toast.add({ title: 'Category updated' })
+        return updated.find(c => c.$id === id) ?? null
+      } else {
+        const { databases } = useAppwrite()
+        const doc = await databases.updateDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.CATEGORIES,
+          documentId: id,
+          data
+        })
+        const category = doc as unknown as Category
+        const updated = vaultStore.categories.map(c => c.$id === id ? category : c)
+        vaultStore.setCategories(updated)
+        toast.add({ title: 'Category updated' })
+        return category
+      }
+    } catch (error) {
+      console.error('Failed to update category:', error)
+      toast.add({ title: 'Failed to update category', color: 'error' })
+      return null
+    }
+  }
+
+  async function deleteCategory(id: string): Promise<boolean> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        vaultStore.setCategories(vaultStore.categories.filter(c => c.$id !== id))
+        toast.add({ title: 'Category deleted' })
+        return true
+      } else {
+        const { databases } = useAppwrite()
+        await databases.deleteDocument({
+          databaseId: APPWRITE.DATABASE_ID,
+          collectionId: APPWRITE.COLLECTIONS.CATEGORIES,
+          documentId: id
+        })
+        vaultStore.setCategories(vaultStore.categories.filter(c => c.$id !== id))
+        toast.add({ title: 'Category deleted' })
+        return true
+      }
+    } catch (error) {
+      console.error('Failed to delete category:', error)
+      toast.add({ title: 'Failed to delete category', color: 'error' })
+      return false
+    }
+  }
+
+  // ─── Thumbnail Upload ───────────────────────
+
+  async function uploadThumbnail(file: File): Promise<string | null> {
+    try {
+      if (MOCK_MODE) {
+        await new Promise(resolve => setTimeout(resolve, 500))
+        toast.add({ title: 'Thumbnail uploaded (mock)' })
+        return `mock-file-${Date.now()}`
+      } else {
+        const { storage, ID } = useAppwrite()
+        const result = await storage.createFile({
+          bucketId: APPWRITE.BUCKETS.THUMBNAILS,
+          fileId: ID.unique(),
+          file
+        })
+        toast.add({ title: 'Thumbnail uploaded' })
+        return result.$id
+      }
+    } catch (error) {
+      console.error('Failed to upload thumbnail:', error)
+      toast.add({ title: 'Upload failed', color: 'error' })
+      return null
+    }
+  }
+
+  // ─── Stats ──────────────────────────────────
+
+  const stats = computed(() => ({
+    resourceCount: vaultStore.resources.length,
+    categoryCount: vaultStore.categories.length,
+    freeResourceCount: vaultStore.resources.filter(r => r.isFree).length,
+    premiumResourceCount: vaultStore.resources.filter(r => !r.isFree).length
+  }))
+
+  return {
+    createResource,
+    updateResource,
+    deleteResource,
+    createResourceCode,
+    updateResourceCode,
+    createCategory,
+    updateCategory,
+    deleteCategory,
+    uploadThumbnail,
+    stats
+  }
+}

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -55,6 +55,7 @@ export function useAuth() {
           const savedSession = localStorage.getItem('vault-mock-session')
           if (savedSession) {
             authStore.setUser(JSON.parse(savedSession) as UserProfile)
+            authStore.setAccountLabels(['admin'])
           }
         }
       } else {
@@ -71,6 +72,7 @@ export function useAuth() {
         } catch {
           // Profile may not exist yet for new users
         }
+        authStore.setAccountLabels((user as unknown as Record<string, string[]>).labels ?? [])
         authStore.setUser(mapAppwriteUser(user as unknown as Record<string, unknown>, profile))
       }
     } catch {
@@ -98,6 +100,7 @@ export function useAuth() {
           displayName: email.split('@')[0] || mockUser.displayName
         }
         authStore.setUser(user)
+        authStore.setAccountLabels(['admin'])
         if (import.meta.client) {
           localStorage.setItem('vault-mock-session', JSON.stringify(user))
         }
@@ -105,6 +108,7 @@ export function useAuth() {
         const { account, databases } = useAppwrite()
         await account.createEmailPasswordSession({ email, password })
         const user = await account.get()
+        authStore.setAccountLabels((user as unknown as Record<string, string[]>).labels ?? [])
         let profile: Record<string, unknown> | null = null
         try {
           profile = await databases.getDocument({
@@ -146,6 +150,7 @@ export function useAuth() {
           email
         }
         authStore.setUser(user)
+        authStore.setAccountLabels(['admin'])
         if (import.meta.client) {
           localStorage.setItem('vault-mock-session', JSON.stringify(user))
         }
@@ -156,6 +161,7 @@ export function useAuth() {
         // Auto-login after registration
         await account.createEmailPasswordSession({ email, password })
         const user = await account.get()
+        authStore.setAccountLabels((user as unknown as Record<string, string[]>).labels ?? [])
         // Create user profile document (for subscription tracking)
         try {
           await databases.createDocument({
@@ -230,6 +236,7 @@ export function useAuth() {
           displayName: `${provider.charAt(0).toUpperCase() + provider.slice(1)} User`
         }
         authStore.setUser(user)
+        authStore.setAccountLabels(['admin'])
         if (import.meta.client) {
           localStorage.setItem('vault-mock-session', JSON.stringify(user))
         }
@@ -265,6 +272,7 @@ export function useAuth() {
     loginWithOAuth,
     user: computed(() => authStore.user),
     isAuthenticated: computed(() => authStore.isAuthenticated),
+    isAdmin: computed(() => authStore.isAdmin),
     isSubscribed: computed(() => authStore.isSubscribed),
     loading: computed(() => authStore.loading),
     initialized: computed(() => authStore.initialized)

--- a/app/layouts/admin.vue
+++ b/app/layouts/admin.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+// Load categories and resources for admin pages
+const { loadCategories } = useCategories()
+const { loadResources } = useResources()
+
+onMounted(async () => {
+  await Promise.all([
+    loadCategories(),
+    loadResources()
+  ])
+})
+</script>
+
+<template>
+  <UDashboardGroup unit="px">
+    <AdminSidebar />
+
+    <UDashboardPanel>
+      <UDashboardNavbar>
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+
+        <template #right>
+          <UBadge
+            color="warning"
+            variant="subtle"
+          >
+            Admin
+          </UBadge>
+        </template>
+      </UDashboardNavbar>
+
+      <slot />
+    </UDashboardPanel>
+  </UDashboardGroup>
+</template>

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -1,0 +1,17 @@
+// Redirect non-admin users to vault
+export default defineNuxtRouteMiddleware(async () => {
+  const { isAuthenticated, isAdmin, init, initialized } = useAuth()
+
+  // Ensure auth state is initialized
+  if (!initialized.value) {
+    await init()
+  }
+
+  if (!isAuthenticated.value) {
+    return navigateTo('/login')
+  }
+
+  if (!isAdmin.value) {
+    return navigateTo('/vault')
+  }
+})

--- a/app/pages/admin/categories.vue
+++ b/app/pages/admin/categories.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { Category, CategoryWithCount } from '~/types'
+
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin'
+})
+
+useSeoMeta({
+  title: 'Manage Categories'
+})
+
+const { categoriesWithCount } = useCategories()
+const { createCategory, updateCategory, deleteCategory } = useAdmin()
+
+// Table columns
+const columns: TableColumn<CategoryWithCount>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name'
+  },
+  {
+    accessorKey: 'slug',
+    header: 'Slug'
+  },
+  {
+    accessorKey: 'icon',
+    header: 'Icon',
+    cell: ({ row }) => h(resolveComponent('UIcon'), {
+      name: row.original.icon,
+      class: 'size-5'
+    })
+  },
+  {
+    accessorKey: 'count',
+    header: 'Resources'
+  },
+  {
+    accessorKey: 'sortOrder',
+    header: 'Order'
+  },
+  {
+    id: 'actions',
+    header: '',
+    cell: ({ row }) => h('div', { class: 'flex gap-1' }, [
+      h(resolveComponent('UButton'), {
+        icon: 'i-lucide-pencil',
+        variant: 'ghost',
+        color: 'neutral',
+        size: 'xs',
+        onClick: () => openEditModal(row.original)
+      }),
+      h(resolveComponent('UButton'), {
+        icon: 'i-lucide-trash-2',
+        variant: 'ghost',
+        color: 'error',
+        size: 'xs',
+        onClick: () => confirmDelete(row.original)
+      })
+    ])
+  }
+]
+
+// Edit/Create modal
+const modalOpen = ref(false)
+const editingCategory = ref<Category | null>(null)
+const formState = reactive({
+  name: '',
+  slug: '',
+  icon: '',
+  sortOrder: 0
+})
+
+function openCreateModal() {
+  editingCategory.value = null
+  Object.assign(formState, { name: '', slug: '', icon: '', sortOrder: 0 })
+  modalOpen.value = true
+}
+
+function openEditModal(category: Category) {
+  editingCategory.value = category
+  Object.assign(formState, {
+    name: category.name,
+    slug: category.slug,
+    icon: category.icon,
+    sortOrder: category.sortOrder
+  })
+  modalOpen.value = true
+}
+
+// Auto-generate slug from name (only for new categories)
+watch(() => formState.name, (name) => {
+  if (!editingCategory.value) {
+    formState.slug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+  }
+})
+
+const saving = ref(false)
+
+async function handleSave() {
+  saving.value = true
+  try {
+    if (editingCategory.value) {
+      await updateCategory(editingCategory.value.$id, { ...formState })
+    } else {
+      await createCategory({ ...formState } as Omit<Category, '$id'>)
+    }
+    modalOpen.value = false
+  } finally {
+    saving.value = false
+  }
+}
+
+// Delete confirmation
+const deleteModalOpen = ref(false)
+const categoryToDelete = ref<Category | null>(null)
+
+function confirmDelete(category: Category) {
+  categoryToDelete.value = category
+  deleteModalOpen.value = true
+}
+
+async function handleDelete() {
+  if (!categoryToDelete.value) return
+  await deleteCategory(categoryToDelete.value.$id)
+  deleteModalOpen.value = false
+  categoryToDelete.value = null
+}
+</script>
+
+<template>
+  <div class="p-4 sm:p-6 space-y-4">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold">
+        Categories
+      </h1>
+      <UButton
+        icon="i-lucide-plus"
+        label="New Category"
+        @click="openCreateModal"
+      />
+    </div>
+
+    <UTable
+      :data="categoriesWithCount"
+      :columns="columns"
+    />
+
+    <!-- Edit/Create Modal -->
+    <UModal v-model:open="modalOpen">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h3 class="text-lg font-semibold">
+            {{ editingCategory ? 'Edit Category' : 'New Category' }}
+          </h3>
+          <UForm
+            :state="formState"
+            class="space-y-4"
+            @submit="handleSave"
+          >
+            <UFormField
+              label="Name"
+              name="name"
+            >
+              <UInput v-model="formState.name" />
+            </UFormField>
+            <UFormField
+              label="Slug"
+              name="slug"
+            >
+              <UInput v-model="formState.slug" />
+            </UFormField>
+            <UFormField
+              label="Icon"
+              name="icon"
+              hint="e.g. i-lucide-sparkles"
+            >
+              <div class="flex items-center gap-2">
+                <UInput
+                  v-model="formState.icon"
+                  class="flex-1"
+                />
+                <UIcon
+                  v-if="formState.icon"
+                  :name="formState.icon"
+                  class="size-5 text-muted"
+                />
+              </div>
+            </UFormField>
+            <UFormField
+              label="Sort Order"
+              name="sortOrder"
+            >
+              <UInput
+                v-model="formState.sortOrder"
+                type="number"
+              />
+            </UFormField>
+            <div class="flex justify-end gap-2">
+              <UButton
+                variant="outline"
+                color="neutral"
+                label="Cancel"
+                @click="modalOpen = false"
+              />
+              <UButton
+                type="submit"
+                :loading="saving"
+                :label="editingCategory ? 'Update' : 'Create'"
+              />
+            </div>
+          </UForm>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Delete confirmation modal -->
+    <UModal v-model:open="deleteModalOpen">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h3 class="text-lg font-semibold">
+            Delete Category
+          </h3>
+          <p class="text-sm text-muted">
+            Delete "{{ categoryToDelete?.name }}"? Resources in this category will become uncategorized.
+          </p>
+          <div class="flex justify-end gap-2">
+            <UButton
+              variant="outline"
+              color="neutral"
+              label="Cancel"
+              @click="deleteModalOpen = false"
+            />
+            <UButton
+              color="error"
+              label="Delete"
+              @click="handleDelete"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin'
+})
+
+useSeoMeta({
+  title: 'Admin Dashboard'
+})
+
+const { stats } = useAdmin()
+const { categoriesWithCount } = useCategories()
+</script>
+
+<template>
+  <div class="p-4 sm:p-6 space-y-6">
+    <h1 class="text-2xl font-bold">
+      Dashboard
+    </h1>
+
+    <!-- Stats cards -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <UCard>
+        <div class="flex items-center gap-3">
+          <UIcon
+            name="i-lucide-file-code"
+            class="size-8 text-primary"
+          />
+          <div>
+            <p class="text-2xl font-bold">
+              {{ stats.resourceCount }}
+            </p>
+            <p class="text-sm text-muted">
+              Total Resources
+            </p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard>
+        <div class="flex items-center gap-3">
+          <UIcon
+            name="i-lucide-folder"
+            class="size-8 text-primary"
+          />
+          <div>
+            <p class="text-2xl font-bold">
+              {{ stats.categoryCount }}
+            </p>
+            <p class="text-sm text-muted">
+              Categories
+            </p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard>
+        <div class="flex items-center gap-3">
+          <UIcon
+            name="i-lucide-unlock"
+            class="size-8 text-green-500"
+          />
+          <div>
+            <p class="text-2xl font-bold">
+              {{ stats.freeResourceCount }}
+            </p>
+            <p class="text-sm text-muted">
+              Free Resources
+            </p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard>
+        <div class="flex items-center gap-3">
+          <UIcon
+            name="i-lucide-lock"
+            class="size-8 text-yellow-500"
+          />
+          <div>
+            <p class="text-2xl font-bold">
+              {{ stats.premiumResourceCount }}
+            </p>
+            <p class="text-sm text-muted">
+              Premium Resources
+            </p>
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- Categories breakdown -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <h2 class="font-semibold">
+            Resources by Category
+          </h2>
+          <UButton
+            to="/admin/categories"
+            variant="ghost"
+            color="neutral"
+            size="xs"
+            label="Manage"
+            trailing-icon="i-lucide-arrow-right"
+          />
+        </div>
+      </template>
+
+      <div class="space-y-3">
+        <div
+          v-for="cat in categoriesWithCount"
+          :key="cat.$id"
+          class="flex items-center justify-between"
+        >
+          <div class="flex items-center gap-2">
+            <UIcon
+              :name="cat.icon"
+              class="size-4 text-muted"
+            />
+            <span class="text-sm">{{ cat.name }}</span>
+          </div>
+          <UBadge
+            :label="String(cat.count)"
+            color="neutral"
+            variant="subtle"
+            size="xs"
+          />
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Quick actions -->
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">
+          Quick Actions
+        </h2>
+      </template>
+
+      <div class="flex flex-wrap gap-2">
+        <UButton
+          to="/admin/resources/new"
+          icon="i-lucide-plus"
+          label="New Resource"
+        />
+        <UButton
+          to="/admin/categories"
+          icon="i-lucide-folder-plus"
+          label="Manage Categories"
+          variant="outline"
+          color="neutral"
+        />
+        <UButton
+          to="/vault"
+          icon="i-lucide-eye"
+          label="View Vault"
+          variant="outline"
+          color="neutral"
+        />
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/app/pages/admin/resources/[id].vue
+++ b/app/pages/admin/resources/[id].vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import type { Resource, ResourceCode } from '~/types'
+
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin'
+})
+
+const route = useRoute()
+const resourceId = computed(() => route.params.id as string)
+
+const { resources } = useResources()
+const { getResourceCode } = useResources()
+const { categories } = useCategories()
+const { updateResource, updateResourceCode, createResourceCode } = useAdmin()
+
+const resource = computed(() =>
+  resources.value.find(r => r.$id === resourceId.value)
+)
+
+const resourceCode = ref<ResourceCode | null>(null)
+const codeLoading = ref(false)
+
+// Load resource code when resource is available
+watch(resource, async (res) => {
+  if (!res) return
+  codeLoading.value = true
+  resourceCode.value = await getResourceCode(res.$id)
+  codeLoading.value = false
+}, { immediate: true })
+
+useSeoMeta({
+  title: computed(() => resource.value ? `Edit: ${resource.value.title}` : 'Edit Resource')
+})
+
+const loading = ref(false)
+
+async function handleSubmit(data: {
+  resource: Partial<Resource>
+  code: Partial<ResourceCode>
+}) {
+  if (!resource.value) return
+  loading.value = true
+  try {
+    await updateResource(resource.value.$id, data.resource)
+    if (resourceCode.value) {
+      await updateResourceCode(resourceCode.value.$id, data.code)
+    } else if (data.code.htmlCode || data.code.cssCode || data.code.jsCode) {
+      await createResourceCode({
+        resourceId: resource.value.$id,
+        htmlCode: data.code.htmlCode ?? '',
+        cssCode: data.code.cssCode ?? '',
+        jsCode: data.code.jsCode ?? '',
+        implementationNotes: data.code.implementationNotes
+      } as Omit<ResourceCode, '$id' | '$createdAt' | '$updatedAt'>)
+    }
+    await navigateTo('/admin/resources')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="p-4 sm:p-6">
+    <div
+      v-if="!resource"
+      class="text-center py-20"
+    >
+      <p class="text-muted">
+        Resource not found.
+      </p>
+      <UButton
+        to="/admin/resources"
+        variant="outline"
+        color="neutral"
+        label="Back to Resources"
+        class="mt-4"
+      />
+    </div>
+    <template v-else>
+      <h1 class="text-2xl font-bold mb-6">
+        Edit: {{ resource.title }}
+      </h1>
+      <AdminResourceForm
+        :resource="resource"
+        :resource-code="resourceCode"
+        :categories="categories"
+        :loading="loading || codeLoading"
+        @submit="handleSubmit"
+      />
+    </template>
+  </div>
+</template>

--- a/app/pages/admin/resources/index.vue
+++ b/app/pages/admin/resources/index.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { Resource } from '~/types'
+
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin'
+})
+
+useSeoMeta({
+  title: 'Manage Resources'
+})
+
+const { resources } = useResources()
+const { categoriesWithCount } = useCategories()
+const { deleteResource } = useAdmin()
+
+// Search filter
+const search = ref('')
+
+const filteredResources = computed(() => {
+  if (!search.value.trim()) return resources.value
+  const q = search.value.toLowerCase()
+  return resources.value.filter(r =>
+    r.title.toLowerCase().includes(q)
+    || r.slug.toLowerCase().includes(q)
+  )
+})
+
+// Table columns
+const columns: TableColumn<Resource>[] = [
+  {
+    accessorKey: 'title',
+    header: 'Title'
+  },
+  {
+    accessorKey: 'slug',
+    header: 'Slug'
+  },
+  {
+    accessorKey: 'category',
+    header: 'Category',
+    cell: ({ row }) => {
+      const cat = categoriesWithCount.value.find(
+        c => c.$id === row.original.category
+      )
+      return cat?.name ?? row.original.category
+    }
+  },
+  {
+    accessorKey: 'isFree',
+    header: 'Access',
+    cell: ({ row }) => {
+      return h(resolveComponent('UBadge'), {
+        color: row.original.isFree ? 'success' : 'warning',
+        variant: 'subtle'
+      }, () => row.original.isFree ? 'Free' : 'Pro')
+    }
+  },
+  {
+    accessorKey: 'isNew',
+    header: 'New',
+    cell: ({ row }) => {
+      return row.original.isNew
+        ? h(resolveComponent('UBadge'), { color: 'primary', variant: 'solid', size: 'xs' }, () => 'New')
+        : ''
+    }
+  },
+  {
+    accessorKey: 'sortOrder',
+    header: 'Order'
+  },
+  {
+    id: 'actions',
+    header: '',
+    cell: ({ row }) => {
+      return h('div', { class: 'flex items-center gap-1' }, [
+        h(resolveComponent('UButton'), {
+          icon: 'i-lucide-pencil',
+          variant: 'ghost',
+          color: 'neutral',
+          size: 'xs',
+          to: `/admin/resources/${row.original.$id}`
+        }),
+        h(resolveComponent('UButton'), {
+          icon: 'i-lucide-trash-2',
+          variant: 'ghost',
+          color: 'error',
+          size: 'xs',
+          onClick: () => confirmDelete(row.original)
+        })
+      ])
+    }
+  }
+]
+
+// Delete confirmation
+const deleteModalOpen = ref(false)
+const resourceToDelete = ref<Resource | null>(null)
+
+function confirmDelete(resource: Resource) {
+  resourceToDelete.value = resource
+  deleteModalOpen.value = true
+}
+
+async function handleDelete() {
+  if (!resourceToDelete.value) return
+  await deleteResource(resourceToDelete.value.$id)
+  deleteModalOpen.value = false
+  resourceToDelete.value = null
+}
+</script>
+
+<template>
+  <div class="p-4 sm:p-6 space-y-4">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold">
+        Resources
+      </h1>
+      <UButton
+        to="/admin/resources/new"
+        icon="i-lucide-plus"
+        label="New Resource"
+      />
+    </div>
+
+    <UInput
+      v-model="search"
+      placeholder="Search resources..."
+      icon="i-lucide-search"
+      class="max-w-sm"
+    />
+
+    <UTable
+      :data="filteredResources"
+      :columns="columns"
+    />
+
+    <!-- Delete confirmation modal -->
+    <UModal v-model:open="deleteModalOpen">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h3 class="text-lg font-semibold">
+            Delete Resource
+          </h3>
+          <p class="text-sm text-muted">
+            Are you sure you want to delete "{{ resourceToDelete?.title }}"?
+            This action cannot be undone.
+          </p>
+          <div class="flex justify-end gap-2">
+            <UButton
+              variant="outline"
+              color="neutral"
+              label="Cancel"
+              @click="deleteModalOpen = false"
+            />
+            <UButton
+              color="error"
+              label="Delete"
+              @click="handleDelete"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/app/pages/admin/resources/new.vue
+++ b/app/pages/admin/resources/new.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import type { Resource, ResourceCode } from '~/types'
+
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin'
+})
+
+useSeoMeta({
+  title: 'New Resource'
+})
+
+const { categories } = useCategories()
+const { createResource, createResourceCode } = useAdmin()
+
+const loading = ref(false)
+
+async function handleSubmit(data: {
+  resource: Partial<Resource>
+  code: Partial<ResourceCode>
+}) {
+  loading.value = true
+  try {
+    const resource = await createResource(data.resource as Omit<Resource, '$id' | '$createdAt' | '$updatedAt' | 'thumbnailUrl'>)
+    if (resource && (data.code.htmlCode || data.code.cssCode || data.code.jsCode)) {
+      await createResourceCode({
+        resourceId: resource.$id,
+        htmlCode: data.code.htmlCode ?? '',
+        cssCode: data.code.cssCode ?? '',
+        jsCode: data.code.jsCode ?? '',
+        implementationNotes: data.code.implementationNotes
+      } as Omit<ResourceCode, '$id' | '$createdAt' | '$updatedAt'>)
+    }
+    await navigateTo('/admin/resources')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="p-4 sm:p-6">
+    <h1 class="text-2xl font-bold mb-6">
+      New Resource
+    </h1>
+    <AdminResourceForm
+      :categories="categories"
+      :loading="loading"
+      @submit="handleSubmit"
+    />
+  </div>
+</template>

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -3,6 +3,7 @@ import type { UserProfile, SubscriptionStatus } from '~/types'
 
 interface AuthState {
   user: UserProfile | null
+  accountLabels: string[]
   loading: boolean
   initialized: boolean
 }
@@ -10,12 +11,14 @@ interface AuthState {
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     user: null,
+    accountLabels: [],
     loading: false,
     initialized: false
   }),
 
   getters: {
     isAuthenticated: (state): boolean => !!state.user,
+    isAdmin: (state): boolean => state.accountLabels.includes('admin'),
     isSubscribed: (state): boolean => state.user?.subscriptionStatus === 'active',
     subscriptionStatus: (state): SubscriptionStatus => state.user?.subscriptionStatus ?? 'free',
     displayName: (state): string => state.user?.displayName ?? '',
@@ -35,6 +38,10 @@ export const useAuthStore = defineStore('auth', {
       this.user = user
     },
 
+    setAccountLabels(labels: string[]) {
+      this.accountLabels = labels
+    },
+
     setLoading(loading: boolean) {
       this.loading = loading
     },
@@ -45,6 +52,7 @@ export const useAuthStore = defineStore('auth', {
 
     clear() {
       this.user = null
+      this.accountLabels = []
       this.loading = false
     }
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,7 +3,6 @@ export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
     '@nuxt/ui',
-    '@nuxt/content',
     '@nuxt/image',
     '@nuxt/scripts',
     '@pinia/nuxt'


### PR DESCRIPTION
## Summary
- Admin role detection via Appwrite User Labels (`labels.includes('admin')`)
- `admin.ts` middleware protects all `/admin/*` routes
- Admin layout with sidebar navigation (Dashboard, Resources, Categories)
- `useAdmin` composable with full CRUD for resources, categories, and thumbnail uploads
- Admin dashboard with stats (total/free/premium resources, categories)
- Resource management: table view with search, create/edit form, delete confirmation
- Category management: table with inline create/edit modal, delete confirmation
- Conditional "Admin Panel" link in user menu for admin users
- Project roadmap added to CLAUDE.md
- Removed stale `@nuxt/content` reference from nuxt.config.ts

## Test plan
- [ ] `pnpm lint` passes (0 errors)
- [ ] `pnpm dev` starts without errors
- [ ] `/admin` redirects to `/login` when not authenticated
- [ ] `/admin` redirects to `/vault` when authenticated but not admin
- [ ] `/admin` accessible when user has 'admin' label
- [ ] Admin dashboard shows resource/category stats
- [ ] Resource CRUD: create, edit, delete works
- [ ] Category CRUD: create, edit, delete works
- [ ] Mock mode: all admin operations work with in-memory data

🤖 Generated with [Claude Code](https://claude.com/claude-code)